### PR TITLE
Remove google-site-verification tag

### DIFF
--- a/source/_includes/head.html
+++ b/source/_includes/head.html
@@ -1,7 +1,6 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-	<meta name="google-site-verification" content="f1OtvP7JCHm6M9Ca7vMcFg3q-1NEOvDMcSKfKlVW_pA" />
 	<script data-cfasync="false" type="text/javascript" src="//use.typekit.net/axj3cfp.js"></script>
 	<script data-cfasync="false" type="text/javascript">try{Typekit.load();}catch(e){}</script>
 	<meta charset="utf-8">


### PR DESCRIPTION
This shouldn't be included by default, since it's specific to a single
domain.
