### PR TITLE
Refactor categories (tags) section in posts a little

### DIFF
--- a/source/_includes/archive_post.html
+++ b/source/_includes/archive_post.html
@@ -10,8 +10,8 @@
 <article>
 	<h2 class="title"><a href="{{ root_url }}{{ post.url }}">{{post.title}}</a></h2>
 	<div class="meta">
-		<span class="date">{{ date | date: "%b %e" }}</span>
-		<span class="tags">{% include post/categories.html %}</span>
+		<div class="date">{{ date | date: "%b %e" }}</div>
+		{% include post/categories.html %}
 	    {% if site.disqus_short_name and post.comments == true and site.disqus_show_comment_count == true %}
 	    <span class="comments"><a href="{{ root_url }}{{ post.url }}#disqus_thread">Comments</a></span>
 	    {% endif %}

--- a/source/_includes/article.html
+++ b/source/_includes/article.html
@@ -19,7 +19,7 @@
 
 <div class="meta">
 	<div class="date">{% include post/date.html %}{{ time }}</div>
-	<div class="tags">{% include post/categories.html %}</div>
+	{% include post/categories.html %}
 	{% if site.disqus_short_name and site.disqus_show_comment_count == true %}
 		<span class="comments"><a href="{{ root_url }}{{ post.url }}{{ page.url }}#disqus_thread">Comments</a></span>
 	{% endif %}

--- a/source/_includes/post/categories.html
+++ b/source/_includes/post/categories.html
@@ -1,8 +1,10 @@
 {% capture category %}{% if post %}{{ post.categories | category_links | size }}{% else %}{{ page.categories | category_links | size }}{% endif %}{% endcapture %}
 {% unless category == '0' %}
+<div class="tags">
 {% if post %}
 	{{ post.categories | category_links }}
 {% else %}
 	{{ page.categories | category_links }}
 {% endif %}
+</div>
 {% endunless %}


### PR DESCRIPTION
I turned the outer span/div tag (different in _includes/archive_post.html and _includes/article.html) into a div tag that is conditional on the presence of article categories.  Before this change, the outer div/span tag would be present whether or not any categories were present; thus the little tag icon would be displayed even when there were no categories.
