### PR TITLE
Allow disqus to load over http or https

### DIFF
--- a/source/_includes/disqus.html
+++ b/source/_includes/disqus.html
@@ -14,7 +14,7 @@
       {% endif %}
     (function () {
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      dsq.src = 'http://' + disqus_shortname + '.disqus.com/' + disqus_script;
+      dsq.src = '//' + disqus_shortname + '.disqus.com/' + disqus_script;
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     }());
 </script>


### PR DESCRIPTION
This allows disqus comments to be loaded over https as per the instructions [here](http://help.disqus.com/customer/portal/articles/542119)
