### PR TITLE
Fixed Error 404

### DIFF
--- a/source/_includes/custom/fancybox_head.html
+++ b/source/_includes/custom/fancybox_head.html
@@ -1,5 +1,4 @@
-<link rel="stylesheet" href="/fancybox/jquery.fancybox.css" type="text/css" media="screen" />
-<script type="text/javascript" src="/fancybox/jquery.fancybox.pack.js"></script>
+<script type="text/javascript" src="/javascripts/jquery.fancybox.pack.js"></script>
 
 <script language="Javascript" type="text/javascript">
 $(document).ready(


### PR DESCRIPTION
Wrong path to fancybox in the fanybox_head.html. (#9) 
The link to the stylesheet can be removed, because all styles are set in the sass files. 
Greetings,
3c7
