### PR TITLE
Change compile priority for archive styles

### DIFF
--- a/sass/_parts.scss
+++ b/sass/_parts.scss
@@ -2,8 +2,8 @@
 @import "parts/index";
 @import "parts/article";
 @import "parts/post";
-@import "parts/archive";
 @import "parts/comment";
 @import "parts/footer";
 @import "parts/syntax";
 @import "parts/twitter";
+@import "parts/archive";


### PR DESCRIPTION
Resolves Issue # 13 (date and tag icon missing on archive page when installing cleanpress)
