### PR TITLE
Modified the verbose scroll bar on code view should not be displayed.

### DIFF
--- a/sass/parts/_syntax.scss
+++ b/sass/parts/_syntax.scss
@@ -121,7 +121,6 @@ figure.code{
 	td.code{
 		width: 100%;
 		padding-left: 15px;
-		overflow-x: auto;
 	}
 }
 .entry-content .gist{


### PR DESCRIPTION
Thank you for providing the cool theme.

When I described the long sentence on the code view, verbose scroll bar was appeared.
Because you define `overflow-x: auto` where `figure.code.highlight` and `figure.code.td.code`.

``` scss
figure.code{
        // ...
        .highlight{
                overflow-x: auto;
        }
        // ...
        td.code{
                width: 100%;
                padding-left: 15px;
                overflow-x: auto;
        }
}
```

So, I removed the definition `overflow-x: auto`.
- before
  ![before](https://cloud.githubusercontent.com/assets/1687203/3159370/bc5ae988-eb0f-11e3-9e45-638ecc2656a4.png)
- after
  ![after](https://cloud.githubusercontent.com/assets/1687203/3159372/c234ed86-eb0f-11e3-97e1-72a9746fe6ed.png)
