### PR TITLE
Update date.html

### DIFF
--- a/source/_includes/post/date.html
+++ b/source/_includes/post/date.html
@@ -6,8 +6,9 @@
 {% capture updated_formatted %}{{ page.updated_formatted }}{{ post.updated_formatted }}{% endcapture %}
 {% capture was_updated %}{{ updated | size }}{% endcapture %}
 
+<!-- I replaced $date_formatted into $date | date: "%b %e, %Y" in order to fix the date_format bug.  -->
 {% if has_date != '0' %}
-  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date_formatted }}</time>{% endcapture %}
+  {% capture time %}<time datetime="{{ date | datetime | date_to_xmlschema }}" pubdate{% if updated %} data-updated="true"{% endif %}>{{ date | date: "%b %e, %Y"  }}</time>{% endcapture %}
 {% endif %}
 
 {% if was_updated != '0' %}


### PR DESCRIPTION
Found date_format bug in the octopress home page like this .

![date_format_bug](https://cloud.githubusercontent.com/assets/190438/8529829/37c7bc80-23d2-11e5-896b-61a6cd0fc590.png)

So I try to fix it. I replaced $date_formatted into $date | date: "%b %e, %Y".

![ ](https://cloud.githubusercontent.com/assets/10649416/11036470/b28a5b48-8733-11e5-9068-bc6298b67bed.png)

Then it becomes like this.

![ ](https://cloud.githubusercontent.com/assets/10649416/11036546/3078799a-8734-11e5-80c6-8460962bd945.png)
